### PR TITLE
refactor: change type() to isinstance()

### DIFF
--- a/src/exception/qcpy_exception.py
+++ b/src/exception/qcpy_exception.py
@@ -1,3 +1,6 @@
+from numpy.dtypes import Complex64DType, Complex128DType
+
+
 class QcpyException:
 
     def __init__(self, qubits: int, prep: chr):
@@ -17,8 +20,8 @@ class QcpyException:
     def singlegateexcemption(self, qubits_to_apply) -> None:
 
         if (
-            type(qubits_to_apply).__module__ != "complex64"
-            and type(qubits_to_apply).__module__ != "complex128"
+            not isinstance(qubits_to_apply, Complex64DType)
+            and not isinstance(qubits_to_apply, Complex128DType)
             and not isinstance(qubits_to_apply, int)
             and not hasattr(qubits_to_apply, "__len__")
         ):

--- a/src/exception/tools_exception.py
+++ b/src/exception/tools_exception.py
@@ -14,12 +14,10 @@ class ToolsException:
         if round <= 0:
             exit(1)
 
-        if (type(show_bit) != int and show_bit > 0) or (
-            type(show_bit) != str or type(show_bit) != int
+        if (not isinstance(show_bit, int) and show_bit > 0) or (
+            not isinstance(show_bit, str) or not isinstance(show_bit, int)
         ):
             exit(1)
-        # if type(amplitude) == int and 2**size <= amplitude and :
-        #     exit(1)
 
     def test_phase_angle(self, show_bit, round: int, radian: bool):
         pass

--- a/src/quantum_circuit/base/base_single_gate.py
+++ b/src/quantum_circuit/base/base_single_gate.py
@@ -12,7 +12,7 @@ class BaseSingleGate(SingleGateInterface):
 
     def __create_gate_queue__(self, qubits_to_apply, gate: np.array):
         gate_queue = np.array([identity()] * self.qubits)
-        if type(qubits_to_apply) == int:
+        if isinstance(qubits_to_apply, int):
             gate_queue[qubits_to_apply] = gate
         elif hasattr(qubits_to_apply, "__len__"):
             for i in qubits_to_apply:

--- a/src/quantum_circuit/gpu/gpu_single_gate.py
+++ b/src/quantum_circuit/gpu/gpu_single_gate.py
@@ -12,7 +12,7 @@ class GpuSingleGate(SingleGateInterface):
     def __create_gate_queue__(self, qubits_to_apply, gate: cp.array):
         gpu_identity = cp.array(identity())
         gate_queue = cp.array([gpu_identity] * self.qubits)
-        if type(qubits_to_apply) == int:
+        if isinstance(qubits_to_apply, int):
             gate_queue[qubits_to_apply] = gate
         elif hasattr(qubits_to_apply, "__len__"):
             for i in qubits_to_apply:

--- a/src/quantum_circuit/gpu_sparse/gpu_sparse_single_gate.py
+++ b/src/quantum_circuit/gpu_sparse/gpu_sparse_single_gate.py
@@ -13,7 +13,7 @@ class GpuSparseSingleGate(SingleGateInterface):
     def __create_gate_queue__(self, qubits_to_apply, gate: cp.array):
         gpu_identity = cp.array(identity())
         gate_queue = cp.array([gpu_identity] * self.qubits)
-        if type(qubits_to_apply) == int:
+        if isinstance(qubits_to_apply, int):
             gate_queue[qubits_to_apply] = gate
         elif hasattr(qubits_to_apply, "__len__"):
             for i in qubits_to_apply:

--- a/src/quantum_circuit/quantum_circuit.py
+++ b/src/quantum_circuit/quantum_circuit.py
@@ -59,7 +59,7 @@ class QuantumCircuit:
         return self.circuit_drawing.make()
 
     def __add_single_drawing__(self, qubits_to_apply, gate: str) -> None:
-        if type(qubits_to_apply) != int:
+        if not isinstance(qubits_to_apply, int):
             for qubit in qubits_to_apply:
                 self.circuit_drawing.insert_single(gate, qubit)
         else:

--- a/src/quantum_circuit/sparse/sparse_single_gate.py
+++ b/src/quantum_circuit/sparse/sparse_single_gate.py
@@ -12,7 +12,7 @@ class SparseSingleGate(SingleGateInterface):
     def __create_gate_queue__(self, qubits_to_apply, gate):
         sparse_identity = sp.csr_matrix(identity())
         gate_queue = [sparse_identity] * self.qubits
-        if type(qubits_to_apply) == int:
+        if isinstance(qubits_to_apply, int):
             gate_queue[qubits_to_apply] = gate
         elif hasattr(qubits_to_apply, "__len__"):
             for i in qubits_to_apply:

--- a/src/tools/amplitude.py
+++ b/src/tools/amplitude.py
@@ -7,13 +7,13 @@ def amplitude(quantumstate, show_bit=-1, round: int = 3, radian: bool = False):
     quantumstate = convert_state(quantumstate)
     size = int(log2(quantumstate.size))
     ToolsException().test_amplitude(show_bit, round, amplitude)
-    if type(show_bit) == int and show_bit < 0:
+    if isinstance(show_bit, int) and show_bit < 0:
         amplitude = sqrt(power(quantumstate.real, 2) + power(quantumstate.imag, 2))
 
-    elif type(show_bit) == str or type(show_bit) == int:
+    elif isinstance(show_bit, str) or isinstance(show_bit, int):
 
         amplitude = show_bit
-        if type(show_bit) == str:
+        if isinstance(show_bit, str):
             amplitude = int(show_bit, 2)
         amplitude = sqrt(
             power(quantumstate[amplitude].real, 2)

--- a/src/tools/phase_angle.py
+++ b/src/tools/phase_angle.py
@@ -12,13 +12,13 @@ def phase_angle(state, show_bit=-1, round: int = 3, radian: bool = True):
             f"Error: QuantumCircuit.tools.phaseAngle() -- round placement must be a value greater than 0."
         )
 
-    if type(show_bit) == int and show_bit < 0:
+    if isinstance(show_bit, int) and show_bit < 0:
         phaseangle = mod(angle(state), 2 * pi) * (180 / pi)
 
-    elif type(show_bit) == str or type(show_bit) == int:
+    elif isinstance(show_bit, str) or isinstance(show_bit, int):
         phaseangle = show_bit
 
-        if type(show_bit) == str:
+        if isinstance(show_bit, str):
             phaseangle = int(show_bit, 2)
         if 2**size <= phaseangle:
             exit(

--- a/src/tools/probability.py
+++ b/src/tools/probability.py
@@ -13,10 +13,10 @@ def probability(
             f"Error: QuantumCircuit.tools.probabilities() -- round placement must be a value greater than 0."
         )
 
-    if type(show_bit) == int and show_bit < 0:
+    if isinstance(show_bit, int) and show_bit < 0:
         probability = abs(square(quantumstate))
 
-    elif type(show_bit) == str or isinstance(show_bit, int):
+    elif isinstance(show_bit, str) or isinstance(show_bit, int):
 
         if 2**circuit_size <= show_bit:
             exit(


### PR DESCRIPTION
The use of `type()` throughout the code base is incorrect. It is better to use `isinstance()`.

This PR fixes issue #70.